### PR TITLE
Rerender page on page props change

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -375,7 +375,7 @@ class Admin extends React.Component {
 
     // Initialize page component props
     const pageProps = {
-      key: `${id}:${location.search}:${location.hash}`,
+      key: `${id}:${location.search}`,
       route: {
         id,
         params,

--- a/src/Page.js
+++ b/src/Page.js
@@ -54,21 +54,13 @@ class Page extends React.Component {
     component: undefined,
   };
 
-  constructor(props) {
-    super(props);
-
-    // Destruct named props to filter out props to pass over to page component
-    const { classes, component, controller, ...pageProps } = props;
-
-    this.state = {
-      PageComponent: component,
-      pageProps,
-    };
-  }
-
   render() {
-    const { classes, controller } = this.props;
-    const { PageComponent, pageProps } = this.state;
+    const {
+      classes,
+      controller,
+      component: PageComponent,
+      ...pageProps
+    } = this.props;
     return (
       <div className={classes.root}>
         <PageLoadController ref={controller} />

--- a/tests/pages/example/user/list.js
+++ b/tests/pages/example/user/list.js
@@ -3,7 +3,7 @@ import React from "react";
 
 import { Content, Link, TitleBar, Tools } from "../../../../src";
 
-const UserListPage = ({ data, title }) => (
+const UserListPage = ({ data, title, route: { hash } }) => (
   <>
     <TitleBar title={`${title} (users)`}>
       <Tools>
@@ -11,6 +11,7 @@ const UserListPage = ({ data, title }) => (
       </Tools>
     </TitleBar>
     <Content>
+      <div>Hash: {hash || "none"}</div>
       {data.obj.map(user => (
         <Link key={user.id} route="example.user:read" params={{ id: user.id }}>
           {user.username}


### PR DESCRIPTION
The issue was that location hash changes were not visible to the page
component. It was ccaused by unnecessarily storing the page props in the
state and never updating the state based on props change. This change
skips the state and relies entirely on props.