### PR TITLE
Ship modern JS to npm

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "@babel/preset-env",
+    ["@babel/preset-env", { "targets": { "esmodules": true } }],
     "@babel/preset-react"
   ],
   "plugins": [
@@ -9,9 +9,6 @@
   ],
   "env": {
     "test": {
-      "presets": [
-        ["@babel/preset-env", {"exclude": ["@babel/plugin-transform-regenerator"]}]
-      ],
       "plugins": [
         "@babel/plugin-proposal-class-properties",
         "@babel/plugin-syntax-dynamic-import",

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,7 +1,0 @@
-# Browsers that we support
-
-last 2 version
-not ie <= 8
-> 1%
-maintained node versions
-not dead

--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ Log level per application label:
 ### prefix
 Prefix sets the base url for the router. Use this if the admin app is mounted on a sub-path, i.e. `/bananas/`.
 
+## Browser support
+
+The code shipped to npm uses modern JavaScript, supported natively by all evergreen browsers. If you need deeper browser support, you need to configure your build system to transpile and polyfill `node_modules/` code.
+
+If you use [Create React App](https://facebook.github.io/create-react-app/), which runs Babel on code from npm packages, you can get IE11 support by adding the following to your main entrypoint:
+
+```js
+import "react-app-polyfill/ie11";
+import "react-app-polyfill/stable";
+```
+
 ## Example app
 
 This repo contains an example app in the `app/` folder.


### PR DESCRIPTION
Previously we transpiled down to IE11 and other older browsers, but we
hadn’t set up babel polyfills. Most notably, this meant that the
compiled code referenced a `regeneratorRuntime` variable that wasn’t
defined (it’s supposed to be defined globally through babel polyfills).
In projects using Create React App we hadn’t noticed this, because CRA
runs npm package code through babel, injecting `regeneratorRuntime`.

However, when trying to use django-bananas in Next.js, the undeclared
`regeneratorRuntime`s threw errors. So what to do?

We _could_ include polyfills in django-bananas. But it might be
unexpected that using django-bananas modifies global objects. And both
we and the user of django-bananas might try to assign
`window.regeneratorRuntime` to different versions.

Another way would be to configure babel to use non-global-polluting
polyfills. But that would make the package unnecessarily heavy
considering that many times admins are used in modern browsers only.

This commit changes the babel setup to use the "esmodules" target, which
targets browsers supporting ES Modules. In other words – the evergreen
browsers. This means that `async`/`await` is preserved – no more
`regeneratorRuntime`. It is then up to the user of django-bananas to
transpile further and add polyfills if deeper browser support is wanted.
Create React App is an example of a build pipeline that supports
transforming code from npm packages.

`import`/`export` are still transpiled to `require`/`module.exports` to
support Next.js server side rendering.