### PR TITLE
Adjust the order of which routes are resolved

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -75,11 +75,7 @@ const CustomLoginForm = () => <form>This is a custom login form</form>;
 ReactDOM.render(
   <Bananas.App
     pages={route => import(`./pages/${route}`)}
-    // logLevel="DEBUG"
-    logLevel={{
-      bananas: "INFO",
-      example: "DEBUG",
-    }}
+    logLevel="DEBUG"
     // layout="vertical" // horizontal|vertical
     title="Example"
     theme={exampleAppTheme}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "django-bananas",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "django-bananas",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "author": "Jonas Lundberg",
   "repository": "5monkeys/django-bananas.js",

--- a/src/router.js
+++ b/src/router.js
@@ -167,10 +167,24 @@ export default class Router {
     this.sort();
   }
 
+  multipleParamsRegexp = new RegExp(/\{[^}]+\}/g);
+
+  getAdjustedPathLength = route =>
+    route.path.replace(this.multipleParamsRegexp, "").split("/");
+
   sort() {
-    this.routes = this.routes.sort((route1, route2) =>
-      route1.path < route2.path ? 1 : -1
-    );
+    this.routes = this.routes.sort((route1, route2) => {
+      const path1 = this.getAdjustedPathLength(route1);
+      const path2 = this.getAdjustedPathLength(route2);
+      // If both paths has the same segment length, grade based on ... :
+      return path1.length === path2.length // ... alphabetical order
+        ? path1 < path2
+          ? 1
+          : -1
+        : path1.length < path2.length // ... segment length
+        ? 1
+        : -1;
+    });
   }
 
   on(eventName, handler) {

--- a/tests/router.test.js
+++ b/tests/router.test.js
@@ -75,6 +75,16 @@ test("Has navigation routes", async () => {
   });
 });
 
+test("Has correctly ordered navigation routes", async () => {
+  const router = await getRouter({ anonymous: false });
+
+  const routeIds = router.routes.reduce((aggr, { id }) => aggr.concat(id), []);
+  const readIndex = routeIds.indexOf("example.user:read");
+  const createIndex = routeIds.indexOf("example.user:create");
+
+  expect(createIndex < readIndex).toBe(true);
+});
+
 test("Can lookup route by id", async () => {
   const router = await getRouter();
 


### PR DESCRIPTION
Before this edit routing attempts to:
`/example/fruit/create/`
would fire a request to:
`/example/fruit/{id=create}`

This was happening due to the routes being resolved in the wrong order.
Now we grade the routes by both segment complexity and alphabetical order.
Since "{" is considered less than anything [a-zA-Z] routes containing parameters
will be resolved after alphabetical, "pure" routes.