### PR TITLE
Feature/customizable autofield

### DIFF
--- a/app/src/components/CustomAutoField.js
+++ b/app/src/components/CustomAutoField.js
@@ -1,0 +1,30 @@
+import { InputAdornment, TextField } from "@material-ui/core";
+import { AutoField } from "django-bananas/forms";
+import React from "react";
+
+const CustomTextField = ({ input, fieldProps }) => {
+  return (
+    <TextField
+      InputProps={{
+        startAdornment: <InputAdornment position="start">🍌</InputAdornment>,
+      }}
+      fullWidth={true}
+      variant="outlined"
+      {...input}
+      {...fieldProps}
+    />
+  );
+};
+
+const fieldsByType = {
+  string: {
+    default: { component: CustomTextField },
+  },
+};
+
+const CustomAutoField = props => {
+  console.log("autofield received props: ", props);
+  return <AutoField fieldsByType={fieldsByType} {...props} />;
+};
+
+export default CustomAutoField;

--- a/app/src/pages/example/user/create.js
+++ b/app/src/pages/example/user/create.js
@@ -1,12 +1,80 @@
-import { Typography } from "@material-ui/core";
-import { Content, TitleBar } from "django-bananas";
+import { Box, Button, Typography } from "@material-ui/core";
+import { withStyles } from "@material-ui/core/styles";
+import {
+  AdminContext,
+  Content,
+  TitleBar,
+  ToolBar,
+  Tools,
+} from "django-bananas";
+import { Form } from "django-bananas/forms";
+import PropTypes from "prop-types";
 import React from "react";
 
-export default () => (
-  <>
-    <TitleBar title={"Create User"} back=".." />
-    <Content>
-      <Typography>...form</Typography>
-    </Content>
-  </>
-);
+import AutoField from "../../../components/CustomAutoField";
+
+const styles = theme => ({
+  paper: {
+    margin: theme.spacing(2),
+    padding: theme.spacing(2),
+  },
+  formRoot: {
+    display: "flex",
+    flexDirection: "column",
+    flexGrow: 1,
+    width: "100%",
+    height: "100%",
+    backgroundColor: theme.palette.background.paper,
+  },
+  spacing: {
+    "& > *": {
+      marginTop: 20,
+    },
+  },
+});
+
+class UserForm extends React.Component {
+  static contextType = AdminContext;
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <Form
+        initialValues={{}}
+        route="example.user:create"
+        formProps={{ className: classes.formRoot }}
+      >
+        <TitleBar title="Form" back=".." />
+        <Content>
+          <Typography variant="h4" component="h1">
+            Create
+          </Typography>
+          <Typography gutterBottom variant="body1">
+            This page utilizes a custom AutoField component
+          </Typography>
+          <Box className={classes.spacing}>
+            <AutoField name="username" />
+            <AutoField name="first_name" />
+            <AutoField name="last_name" />
+            <AutoField name="email" />
+            {/* <AutoField name="new_password" /> */}
+          </Box>
+        </Content>
+        <ToolBar color="paper" justify="end">
+          <Tools>
+            <Button type="submit" variant="contained" color="primary">
+              Save
+            </Button>
+          </Tools>
+        </ToolBar>
+      </Form>
+    );
+  }
+}
+
+UserForm.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(UserForm);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "django-bananas",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "license": "MIT",
   "author": "Jonas Lundberg",
   "repository": "5monkeys/django-bananas.js",

--- a/src/forms/AutoField.js
+++ b/src/forms/AutoField.js
@@ -39,19 +39,35 @@ class AutoField extends React.Component {
     const {
       name,
       fieldProps: fieldPropsOverride,
-      variant,
+      fieldsByType: passedFieldsByType,
+      FinalFormFieldProps,
       ...rest
     } = this.props;
     const schema = fieldFromSchema(this.context.schema, name);
     if (typeof schema === "undefined") {
       throw new Error(`No schema found for field "${name}".`);
     }
+
+    const mergedFieldsByType = {
+      ...fieldsByType,
+      ...passedFieldsByType,
+      string: {
+        ...fieldsByType.string,
+        ...(passedFieldsByType.string || {}),
+      },
+    };
+
+    const fieldMapping = {
+      ...fieldsByType,
+      ...mergedFieldsByType,
+    };
+
     const fieldType = schema.enum ? "enum" : schema.type;
-    const fields = fieldsByType[fieldType] || fieldsByType.string;
+    const fields = fieldMapping[fieldType] || fieldMapping.string;
     const { component: Field, type } = fields[schema.format] || fields.default;
 
     return (
-      <FField name={name} type={type} {...rest} novalidate>
+      <FField name={name} type={type} novalidate {...FinalFormFieldProps}>
         {({ meta, input }) => {
           const fieldProps = schema
             ? {
@@ -64,9 +80,9 @@ class AutoField extends React.Component {
             <Field
               meta={meta}
               input={input}
-              variant={variant}
               schema={schema}
               fieldProps={{ ...fieldProps, ...fieldPropsOverride }}
+              {...rest}
             />
           );
         }}
@@ -77,13 +93,15 @@ class AutoField extends React.Component {
 
 AutoField.propTypes = {
   name: PropTypes.string.isRequired,
-  variant: PropTypes.string,
   fieldProps: PropTypes.object,
+  fieldsByType: PropTypes.object,
+  FinalFormFieldProps: PropTypes.object,
 };
 
 AutoField.defaultProps = {
-  variant: undefined,
   fieldProps: {},
+  fieldsByType: {},
+  FinalFormFieldProps: {},
 };
 
 export default AutoField;

--- a/src/forms/Form.js
+++ b/src/forms/Form.js
@@ -47,8 +47,12 @@ class Form extends React.Component {
 
   handleSubmit = values => {
     const { route, params, onSubmit } = this.props;
-    const endpoint = data =>
-      this.context.api[route]({ ...params, data: data || values });
+    const endpoint = (data, passedParams = {}) =>
+      this.context.api[route]({
+        ...params,
+        ...passedParams,
+        data: data || values,
+      });
     const promise = onSubmit
       ? Promise.resolve(onSubmit({ endpoint, values }))
       : endpoint().then(() => {

--- a/src/forms/Form.js
+++ b/src/forms/Form.js
@@ -46,7 +46,7 @@ class Form extends React.Component {
   }
 
   handleSubmit = values => {
-    const { route, params, onSubmit } = this.props;
+    const { route, params, onSubmit, onSuccess } = this.props;
     const endpoint = (data, passedParams = {}) =>
       this.context.api[route]({
         ...params,
@@ -57,7 +57,11 @@ class Form extends React.Component {
       ? Promise.resolve(onSubmit({ endpoint, values }))
       : endpoint().then(() => {
           // TODO: store data from server in the form
-          this.context.admin.success("Changes have been saved!");
+          if (onSuccess !== undefined) {
+            onSuccess();
+          } else {
+            this.context.admin.success("Changes have been saved!");
+          }
           return false;
         });
 
@@ -105,11 +109,13 @@ Form.propTypes = {
   route: PropTypes.string.isRequired,
   params: PropTypes.object,
   onSubmit: PropTypes.func,
+  onSuccess: PropTypes.func,
   formProps: PropTypes.object,
 };
 
 Form.defaultProps = {
   onSubmit: undefined,
+  onSuccess: undefined,
   params: {},
   formProps: {},
 };

--- a/tests/forms/AutoField.test.js
+++ b/tests/forms/AutoField.test.js
@@ -72,3 +72,84 @@ test.each([
     expect(tree.toJSON()).toMatchSnapshot();
   }
 );
+
+const CustomFieldsByType = {
+  string: {
+    default: { component: () => "text" },
+    date: { component: () => "date" },
+    "date-time": { component: () => "date-time" },
+  },
+  boolean: {
+    default: { component: () => "boolean", type: "checkbox" },
+  },
+  enum: {
+    default: { component: () => "enum", type: "select" },
+  },
+  array: {
+    default: { component: () => "array", type: "select" },
+  },
+};
+
+test.each([
+  ["boolean", "checkbox", "boolean"],
+  ["boolean", "switch", "boolean"],
+  ["date", "default", "date"],
+  ["datetime", "default", "date-time"],
+  ["integer", "default", "text"],
+  ["multiple_choices", "default", "array"],
+  ["text", "default", "text"],
+])(
+  "Can render field of type '%s' and variant '%s' with custom field mapping",
+  async (name, variant, child) => {
+    const api = await getAPIClient();
+    const tree = renderer.create(
+      <TestContext api={api}>
+        <Form route="example.user:form.create">
+          <AutoField
+            fieldsByType={CustomFieldsByType}
+            name={name}
+            variant={variant}
+          />
+        </Form>
+      </TestContext>
+    );
+    expect(tree.toJSON().children[0]).toMatch(child);
+  }
+);
+
+const DateTimeComponent = () => "date-time";
+
+const CustomPartialFieldsByType = {
+  string: {
+    "date-time": { component: DateTimeComponent },
+  },
+};
+
+test.each([
+  ["boolean", "checkbox", BooleanField],
+  ["boolean", "switch", BooleanField],
+  ["choices", "default", ChoiceField],
+  ["date", "default", DateField],
+  ["datetime", "default", DateTimeComponent],
+  ["integer", "default", TextField],
+  ["multiple_choices", "default", MultipleChoiceField],
+  ["text", "default", TextField],
+])(
+  "Can render field of type '%s' and variant '%s' with partial fieldsByType",
+  async (name, variant, fieldComponent) => {
+    const api = await getAPIClient();
+    const tree = renderer.create(
+      <TestContext api={api}>
+        <Form route="example.user:form.create">
+          <AutoField
+            fieldsByType={CustomPartialFieldsByType}
+            name={name}
+            variant={variant}
+          />
+        </Form>
+      </TestContext>
+    );
+    expect(tree.root.findByType(fieldComponent)).toBeTruthy();
+    expect(tree.toJSON()).toMatchSnapshot();
+  }
+);

--- a/tests/forms/__snapshots__/AutoField.test.js.snap
+++ b/tests/forms/__snapshots__/AutoField.test.js.snap
@@ -65,7 +65,135 @@ exports[`Can render field of type 'boolean' and variant 'checkbox' 1`] = `
 </form>
 `;
 
+exports[`Can render field of type 'boolean' and variant 'checkbox' with partial fieldsByType 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root"
+  >
+    <div
+      className="MuiFormGroup-root"
+    >
+      <label
+        className="MuiFormControlLabel-root"
+      >
+        <span
+          aria-disabled={false}
+          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-19 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+          onBlur={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <input
+              checked={false}
+              className="PrivateSwitchBase-input-22"
+              data-indeterminate={false}
+              disabled={false}
+              name="boolean"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </span>
+        </span>
+        <span
+          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+        >
+          Boolean *
+        </span>
+      </label>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`Can render field of type 'boolean' and variant 'switch' 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root"
+  >
+    <div
+      className="MuiFormGroup-root"
+    >
+      <label
+        className="MuiFormControlLabel-root"
+      >
+        <span
+          className="MuiSwitch-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-19 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <span
+                className="MuiSwitch-thumb"
+              />
+              <input
+                checked={false}
+                className="PrivateSwitchBase-input-22 MuiSwitch-input"
+                disabled={false}
+                name="boolean"
+                onChange={[Function]}
+                type="checkbox"
+              />
+            </span>
+          </span>
+          <span
+            className="MuiSwitch-track"
+          />
+        </span>
+        <span
+          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+        >
+          Boolean *
+        </span>
+      </label>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Can render field of type 'boolean' and variant 'switch' with partial fieldsByType 1`] = `
 <form
   onSubmit={[Function]}
 >
@@ -187,7 +315,103 @@ exports[`Can render field of type 'choices' and variant 'default' 1`] = `
 </form>
 `;
 
+exports[`Can render field of type 'choices' and variant 'default' with partial fieldsByType 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root"
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+      data-shrink={false}
+      htmlFor="name-error"
+    >
+      Choices *
+    </label>
+    <div
+      className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+      onClick={[Function]}
+    >
+      <div
+        aria-haspopup="true"
+        aria-pressed="false"
+        className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input MuiInputBase-inputSelect"
+        id="select-choices"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "&#8203;",
+            }
+          }
+        />
+      </div>
+      <input
+        name="choices"
+        type="hidden"
+        value=""
+      />
+      <svg
+        aria-hidden="true"
+        className="MuiSvgIcon-root MuiSelect-icon"
+        focusable="false"
+        role="presentation"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`Can render field of type 'date' and variant 'default' 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiTextField-root"
+    format="MMMM do"
+    onClick={[Function]}
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+      data-shrink={true}
+    >
+      Date *
+    </label>
+    <div
+      className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+      onClick={[Function]}
+    >
+      <input
+        aria-invalid={false}
+        className="MuiInputBase-input MuiInput-input"
+        disabled={false}
+        name="date"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={true}
+        required={false}
+        type="text"
+        value="July 4th"
+      />
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Can render field of type 'date' and variant 'default' with partial fieldsByType 1`] = `
 <form
   onSubmit={[Function]}
 >
@@ -261,7 +485,49 @@ exports[`Can render field of type 'datetime' and variant 'default' 1`] = `
 </form>
 `;
 
+exports[`Can render field of type 'datetime' and variant 'default' with partial fieldsByType 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  date-time
+</form>
+`;
+
 exports[`Can render field of type 'integer' and variant 'default' 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiTextField-root"
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+      data-shrink={false}
+    >
+      Integer *
+    </label>
+    <div
+      className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+      onClick={[Function]}
+    >
+      <input
+        aria-invalid={false}
+        className="MuiInputBase-input MuiInput-input"
+        disabled={false}
+        name="integer"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        required={false}
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Can render field of type 'integer' and variant 'default' with partial fieldsByType 1`] = `
 <form
   onSubmit={[Function]}
 >
@@ -354,7 +620,100 @@ exports[`Can render field of type 'multiple_choices' and variant 'default' 1`] =
 </form>
 `;
 
+exports[`Can render field of type 'multiple_choices' and variant 'default' with partial fieldsByType 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root"
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+      data-shrink={false}
+      htmlFor="name-error"
+    >
+      undefined *
+    </label>
+    <div
+      className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+      onClick={[Function]}
+    >
+      <div
+        aria-haspopup="true"
+        aria-pressed="false"
+        className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input MuiInputBase-inputSelect"
+        id="select-multiple_choices"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "&#8203;",
+            }
+          }
+        />
+      </div>
+      <input
+        name="multiple_choices"
+        type="hidden"
+        value=""
+      />
+      <svg
+        aria-hidden="true"
+        className="MuiSvgIcon-root MuiSelect-icon"
+        focusable="false"
+        role="presentation"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`Can render field of type 'text' and variant 'default' 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiTextField-root"
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+      data-shrink={false}
+    >
+      Text *
+    </label>
+    <div
+      className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+      onClick={[Function]}
+    >
+      <input
+        aria-invalid={false}
+        className="MuiInputBase-input MuiInput-input"
+        disabled={false}
+        name="text"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        required={false}
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Can render field of type 'text' and variant 'default' with partial fieldsByType 1`] = `
 <form
   onSubmit={[Function]}
 >


### PR DESCRIPTION
Make it possible to add a custom fieldMapping for `<AutoField/>`
- Possibly breaking changes for how props works in AutoField.
- Add onSuccess to <Form/>, which triggers after onSubmit has finished without errors.
- Updates to the example app.
- Allow passing params to the endpoint prop in  the`<Form>` `onSubmit` method.
