### PR TITLE
Permission helper functions and components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "django-bananas",
-  "version": "2.0.1",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -23,7 +23,7 @@ import { ErrorPage, LoginPage } from "./pages";
 import Router from "./router";
 import Settings from "./settings";
 import themes, { createBananasTheme } from "./themes";
-import { ComponentProxy, getFromSchema, t } from "./utils";
+import { ComponentProxy, getFromSchema, makeUser, t } from "./utils";
 
 Logger.useDefaults();
 const logger = Logger.get("bananas");
@@ -284,7 +284,9 @@ class Admin extends React.Component {
 
       endpoint().then(
         response => {
-          const user = { ...response.obj };
+          const user = (this.props.customizeUser || (usr => usr))(
+            makeUser(response.obj)
+          );
           const current = this.state.context.user;
           if (JSON.stringify(user) !== JSON.stringify(current)) {
             logger.info("Authorized User:", user);
@@ -637,6 +639,7 @@ class App extends React.Component {
     loginForm: PropTypes.func,
     editableSettings: PropTypes.bool,
     customizeContext: PropTypes.func,
+    customizeUser: PropTypes.func,
   };
 
   static defaultProps = {
@@ -660,6 +663,7 @@ class App extends React.Component {
     loginForm: undefined,
     editableSettings: false,
     customizeContext: undefined,
+    customizeUser: undefined,
   };
 
   render() {

--- a/src/auth/PermissionRequired.js
+++ b/src/auth/PermissionRequired.js
@@ -1,0 +1,44 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import { AdminContext } from "..";
+
+export const permissionRequired = (permission, user) => {
+  return user.permissions.indexOf(permission) !== -1;
+};
+
+export const permissionsRequired = (permissions, user, all = true) => {
+  for (const permission of permissions) {
+    if (permissionRequired(permission, user)) {
+      if (!all) {
+        return true;
+      }
+    } else if (all) {
+      return false;
+    }
+  }
+  return all;
+};
+
+const PermissionRequired = ({ permission, allMustMatch, children }) => {
+  const { user } = React.useContext(AdminContext);
+  const passes = Array.isArray(permission)
+    ? permissionsRequired(permission, user, allMustMatch)
+    : permissionRequired(permission, user);
+  return passes && <>{children}</>;
+};
+
+PermissionRequired.propTypes = {
+  permission: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]).isRequired,
+  allMustMatch: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+PermissionRequired.defaultProps = {
+  allMustMatch: true,
+};
+
+export default PermissionRequired;

--- a/src/auth/PermissionRequired.js
+++ b/src/auth/PermissionRequired.js
@@ -2,29 +2,13 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { AdminContext } from "..";
-
-export const permissionRequired = (permission, user) => {
-  return user.permissions.indexOf(permission) !== -1;
-};
-
-export const permissionsRequired = (permissions, user, all = true) => {
-  for (const permission of permissions) {
-    if (permissionRequired(permission, user)) {
-      if (!all) {
-        return true;
-      }
-    } else if (all) {
-      return false;
-    }
-  }
-  return all;
-};
+import { hasPermissions } from "../utils";
 
 const PermissionRequired = ({ permission, allMustMatch, children }) => {
   const { user } = React.useContext(AdminContext);
   const passes = Array.isArray(permission)
-    ? permissionsRequired(permission, user, allMustMatch)
-    : permissionRequired(permission, user);
+    ? hasPermissions(permission, user, allMustMatch)
+    : user.hasPermission(permission);
   return passes && <>{children}</>;
 };
 

--- a/src/auth/UserPassesTest.js
+++ b/src/auth/UserPassesTest.js
@@ -1,0 +1,17 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import { AdminContext } from "..";
+
+const UserPassesTest = ({ children, testFunc }) => {
+  const { user } = React.useContext(AdminContext);
+  const passed = testFunc(user);
+  return passed && <>{children}</>;
+};
+
+UserPassesTest.propTypes = {
+  children: PropTypes.node.isRequired,
+  testFunc: PropTypes.func.isRequired,
+};
+
+export default UserPassesTest;

--- a/src/utils.js
+++ b/src/utils.js
@@ -223,3 +223,25 @@ function getFromSchemaHelper(schema, pathItems, location) {
 
   return getFromSchemaHelper(schema[key], restPath, [...location, key]);
 }
+
+export const makeUser = responseData => {
+  return {
+    ...responseData,
+    hasPermission(permission) {
+      return this.permissions.indexOf(permission) !== -1;
+    },
+  };
+};
+
+export const hasPermissions = (permissions, user, all = true) => {
+  for (const permission of permissions) {
+    if (user.hasPermission(permission)) {
+      if (!all) {
+        return true;
+      }
+    } else if (all) {
+      return false;
+    }
+  }
+  return all;
+};

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -502,3 +502,19 @@ test("Can customize context", async () => {
   expect(window.__adminContext.userFullName).toBe("Monkey Kong");
   expect(window.__adminContext.websocketClient).toBe(websocketClient);
 });
+
+test("Can customize user", async () => {
+  await renderApp({
+    anonymous: false,
+    props: {
+      customizeUser: usr => ({
+        ...usr,
+        newFunction: () => {
+          return "Monkey business.";
+        },
+      }),
+    },
+  });
+  // `./pages/index.js` sets `window.__adminContext` to the current `AdminContext`.
+  expect(window.__adminContext.user.newFunction()).toBe("Monkey business.");
+});

--- a/tests/auth/PermissionRequired.test.js
+++ b/tests/auth/PermissionRequired.test.js
@@ -1,0 +1,97 @@
+import { cleanup, render } from "@testing-library/react";
+import Logger from "js-logger";
+import React from "react";
+
+import PermissionRequired, {
+  permissionRequired,
+  permissionsRequired,
+} from "../../src/auth/PermissionRequired";
+import { contextData, TestContext } from "./utils";
+
+Logger.get("bananas").setLevel(Logger.OFF);
+
+afterEach(cleanup);
+
+test("Ensure component doesn't show if user lacks permission", async () => {
+  const { getByText } = render(
+    <TestContext>
+      <PermissionRequired permission={"lacks.permission"}>
+        {"Don't show me"}
+      </PermissionRequired>
+    </TestContext>
+  );
+  expect(() => getByText("Don't show me")).toThrow();
+  expect(permissionRequired("lacks.permission", contextData.user)).toBeFalsy();
+});
+
+test("Ensure component shows with multiple permissions", async () => {
+  const { getByText } = render(
+    <TestContext>
+      <PermissionRequired permission={["has.permission", "also.has.this"]}>
+        {"Please show me"}
+      </PermissionRequired>
+    </TestContext>
+  );
+  const text = getByText("Please show me");
+  expect(text).toBeTruthy();
+  expect(permissionRequired("has.permission", contextData.user)).toBeTruthy();
+});
+
+test("Ensure component doesn't show if user has only one permission and allMustMatch is default (true)", async () => {
+  const { getByText } = render(
+    <TestContext>
+      <PermissionRequired permission={["has.permission", "lacks.permission"]}>
+        {"Don't show me"}
+      </PermissionRequired>
+    </TestContext>
+  );
+  expect(() => getByText("Don't show me")).toThrow();
+  expect(
+    permissionsRequired(
+      ["has.permission", "lacks.permission"],
+      contextData.user
+    )
+  ).toBeFalsy();
+});
+
+test("Ensure component shows if user only has one permission and allMustMatch is false", async () => {
+  const { getByText } = render(
+    <TestContext>
+      <PermissionRequired
+        permission={["has.permission", "lacks.permission"]}
+        allMustMatch={false}
+      >
+        {"Don't show me"}
+      </PermissionRequired>
+    </TestContext>
+  );
+  expect(getByText("Don't show me")).toBeTruthy();
+  expect(
+    permissionsRequired(
+      ["has.permission", "lacks.permission"],
+      contextData.user,
+      false
+    )
+  ).toBeTruthy();
+});
+
+test("Ensure component doesn't show if user lacks all permissions and allMustMatch is false", async () => {
+  const { getByText } = render(
+    <TestContext>
+      <PermissionRequired
+        permission={["lacks.this.permission", "lacks.permission"]}
+        allMustMatch={false}
+      >
+        {"Don't show me"}
+      </PermissionRequired>
+    </TestContext>
+  );
+  expect(() => getByText("Don't show me")).toThrow();
+  expect(
+    permissionsRequired(
+      ["lacks.this.permission", "lacks.permission"],
+      contextData.user,
+      false
+    )
+  ).toBeFalsy();
+});

--- a/tests/auth/PermissionRequired.test.js
+++ b/tests/auth/PermissionRequired.test.js
@@ -2,11 +2,8 @@ import { cleanup, render } from "@testing-library/react";
 import Logger from "js-logger";
 import React from "react";
 
-import PermissionRequired, {
-  permissionRequired,
-  permissionsRequired,
-} from "../../src/auth/PermissionRequired";
-import { contextData, TestContext } from "./utils";
+import PermissionRequired from "../../src/auth/PermissionRequired";
+import { TestContext } from "./utils";
 
 Logger.get("bananas").setLevel(Logger.OFF);
 
@@ -21,7 +18,6 @@ test("Ensure component doesn't show if user lacks permission", async () => {
     </TestContext>
   );
   expect(() => getByText("Don't show me")).toThrow();
-  expect(permissionRequired("lacks.permission", contextData.user)).toBeFalsy();
 });
 
 test("Ensure component shows with multiple permissions", async () => {
@@ -34,7 +30,6 @@ test("Ensure component shows with multiple permissions", async () => {
   );
   const text = getByText("Please show me");
   expect(text).toBeTruthy();
-  expect(permissionRequired("has.permission", contextData.user)).toBeTruthy();
 });
 
 test("Ensure component doesn't show if user has only one permission and allMustMatch is default (true)", async () => {
@@ -46,12 +41,6 @@ test("Ensure component doesn't show if user has only one permission and allMustM
     </TestContext>
   );
   expect(() => getByText("Don't show me")).toThrow();
-  expect(
-    permissionsRequired(
-      ["has.permission", "lacks.permission"],
-      contextData.user
-    )
-  ).toBeFalsy();
 });
 
 test("Ensure component shows if user only has one permission and allMustMatch is false", async () => {
@@ -66,13 +55,6 @@ test("Ensure component shows if user only has one permission and allMustMatch is
     </TestContext>
   );
   expect(getByText("Don't show me")).toBeTruthy();
-  expect(
-    permissionsRequired(
-      ["has.permission", "lacks.permission"],
-      contextData.user,
-      false
-    )
-  ).toBeTruthy();
 });
 
 test("Ensure component doesn't show if user lacks all permissions and allMustMatch is false", async () => {
@@ -87,11 +69,4 @@ test("Ensure component doesn't show if user lacks all permissions and allMustMat
     </TestContext>
   );
   expect(() => getByText("Don't show me")).toThrow();
-  expect(
-    permissionsRequired(
-      ["lacks.this.permission", "lacks.permission"],
-      contextData.user,
-      false
-    )
-  ).toBeFalsy();
 });

--- a/tests/auth/UserPassesTest.test.js
+++ b/tests/auth/UserPassesTest.test.js
@@ -1,0 +1,40 @@
+import { cleanup, render } from "@testing-library/react";
+import Logger from "js-logger";
+import React from "react";
+
+import UserPassesTest from "../../src/auth/UserPassesTest";
+import { TestContext } from "./utils";
+
+Logger.get("bananas").setLevel(Logger.OFF);
+
+afterEach(cleanup);
+
+test("Ensure component sends user to testFunc and displays on true", async () => {
+  const testFunc = jest.fn(user => {
+    return user !== undefined;
+  });
+  const { getByText } = render(
+    <TestContext>
+      <UserPassesTest testFunc={user => testFunc(user)}>
+        {"Please show me"}
+      </UserPassesTest>
+    </TestContext>
+  );
+  expect(testFunc).toHaveBeenCalled();
+  expect(() => getByText("Please show me")).toBeTruthy();
+});
+
+test("Ensure component hides if testFunc returns false", async () => {
+  const testFunc = jest.fn(user => {
+    return user === undefined;
+  });
+  const { getByText } = render(
+    <TestContext>
+      <UserPassesTest testFunc={user => testFunc(user)}>
+        {"Don't show me"}
+      </UserPassesTest>
+    </TestContext>
+  );
+  expect(testFunc).toHaveBeenCalled();
+  expect(() => getByText("Don't show me")).toThrow();
+});

--- a/tests/auth/utils.js
+++ b/tests/auth/utils.js
@@ -2,15 +2,16 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { AdminContext } from "../../src";
+import { makeUser } from "../../src/utils";
 
 export const TestContext = ({ user, children }) => (
   <AdminContext.Provider value={{ user }}>{children}</AdminContext.Provider>
 );
 
 export const contextData = {
-  user: {
+  user: makeUser({
     permissions: ["has.permission", "also.has.this"],
-  },
+  }),
 };
 
 TestContext.propTypes = {

--- a/tests/auth/utils.js
+++ b/tests/auth/utils.js
@@ -1,0 +1,26 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import { AdminContext } from "../../src";
+
+export const TestContext = ({ user, children }) => (
+  <AdminContext.Provider value={{ user }}>{children}</AdminContext.Provider>
+);
+
+export const contextData = {
+  user: {
+    permissions: ["has.permission", "also.has.this"],
+  },
+};
+
+TestContext.propTypes = {
+  user: PropTypes.object,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};
+
+TestContext.defaultProps = {
+  user: contextData.user,
+};

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -9,10 +9,12 @@ import {
   ensureTrailingSlash,
   fromQuery,
   getCookie,
+  hasPermissions,
   interpolateString,
   nthIndexOf,
   toQuery,
 } from "../src/utils";
+import { contextData } from "./auth/utils";
 
 Logger.get("bananas").setLevel(Logger.OFF);
 
@@ -119,4 +121,40 @@ test("Can interpolate strings", () => {
 test("Can generate Material UI color shapes", () => {
   const green = "#34A77B";
   expect(createColor(green)).toEqual(django);
+});
+
+test("Default permission checks work as expected", () => {
+  expect(contextData.user.hasPermission("lacks.permission")).toBeFalsy();
+  expect(contextData.user.hasPermission("has.permission")).toBeTruthy();
+  expect(
+    hasPermissions(["has.permission", "lacks.permission"], contextData.user)
+  ).toBeFalsy();
+  expect(
+    hasPermissions(
+      ["has.permission", "lacks.permission"],
+      contextData.user,
+      false
+    )
+  ).toBeTruthy();
+  expect(
+    hasPermissions(
+      ["lacks.this.permission", "lacks.permission"],
+      contextData.user,
+      false
+    )
+  ).toBeFalsy();
+});
+
+test("Can customize permission check on user object", () => {
+  contextData.user.hasPermission = () => {
+    return false;
+  };
+  expect(contextData.user.hasPermission("has.permission")).toBeFalsy();
+  expect(
+    hasPermissions(
+      ["has.permission", "lacks.permission"],
+      contextData.user,
+      false
+    )
+  ).toBeFalsy();
 });


### PR DESCRIPTION
Adds components and functions in a new folder src/auth emulating django permission checking names
- `UserPassesTest` 
  - takes a function `testFunc` that controls whether component will render children (true) or not (false), passing the `AdminContext` user to the function
- `PermissionRequired`
  - expands on `UserPassesTest` functionality by checking if user object has the required permissions. 
  - `permission` (required): accepts a single string with the permission
  - or an array of strings with the required permissions 
  - `allMustMatch` (optional): boolean deciding whether permission checking (if permission is array) is done using OR (false) or AND (true/default)
  - adds function `permissionRequired`
    - takes `permission` (string) and `user` (object) from `AdminContext`
  - adds function `permissionsRequired`
    - takes `permissions` (array of strings)
    - `user` (object) from `AdminContext`
    - `all` (boolean) whether to check permissions using OR (false) or AND (true/default)

Adds tests for components and functions, 100% code coverage on new code.
