### PR TITLE
Allow uri-encoded strings to be queried for

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "django-bananas",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "license": "MIT",
   "author": "Jonas Lundberg",
   "repository": "5monkeys/django-bananas.js",

--- a/src/router.js
+++ b/src/router.js
@@ -96,7 +96,7 @@ export default class Router {
                   `{${param.name}}`,
                   param.type === "integer"
                     ? `(\\d+)` // Named: `(?<${param.name}>\\d+)`
-                    : `([\\w\\d_-]+)` // Named: `(?<${param.name}>[\\w\\d_-]+)`
+                    : `([\\.\\%\\w\\d_-]+)` // Named: `(?<${param.name}>[\\.\\%\\w\\d_-]+)`
                 ),
               `^${path}$`
             )


### PR DESCRIPTION
**Problem**
URI-encoded strings and files are right now not parsed correctly in the router, resulting in a 404 when a value like this is used in the read/-view.

**example:**
`/messages/hello%20there`
`/images/hello.jpg`

In the above cases the router would interpret only the first part and query for `hello`.

**Solution:**
Add `%` and `.` to the router param-regex
