### PR TITLE
ci: use npm trusted publishing (OIDC) with version-skip guard

### DIFF
--- a/.github/workflows/release-django-bananas.yml
+++ b/.github/workflows/release-django-bananas.yml
@@ -6,25 +6,41 @@ on:
     branches:
       - master
     paths:
-      - ".github/workflows/release-djedi-json.yml"
+      - ".github/workflows/release-django-bananas.yml"
       - "package.json"
 
 jobs:
   release:
     name: Build and push npm release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for npm trusted publishing (OIDC)
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
+      - name: Update npm
+        run: npm install -g npm@latest # trusted publishing requires npm >= 11.5.1
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
       - name: Build package
         run: npm run build
+      - name: Check if version is already published
+        id: check
+        run: |
+          local_version="$(node -p "require('./package.json').version")"
+          published_version="$(npm view django-bananas version 2>/dev/null || echo "")"
+          echo "local=$local_version published=$published_version"
+          if [ "$local_version" = "$published_version" ]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "django-bananas@$local_version is already published; skipping."
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish package
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: ./dist/package.json
+        if: steps.check.outputs.should_publish == 'true'
+        run: npm publish
+        working-directory: ./dist


### PR DESCRIPTION
## Summary
- Migrate the npm release workflow from a long-lived `NPM_TOKEN` to **OIDC trusted publishing**, so credentials are minted per-run and never expire. Fixes the `E404` publish failure on the 4.1.2 → 5.0.0 bump (a masked auth failure).
- Replace the `JS-DevTools/npm-publish` action with native `npm publish` and add `permissions: id-token: write`; bump npm to `@latest` (trusted publishing needs npm ≥ 11.5.1).
- Add a **version-skip guard** that compares `package.json` against the published version and only publishes when they differ, restoring idempotent re-runs.
- Fix a stale `paths` trigger that referenced a nonexistent `release-djedi-json.yml`.

## Follow-up required
- Register the trusted publisher on npmjs.com: `django-bananas` → Settings → Trusted Publisher → GitHub Actions, repo `5monkeys/django-bananas.js`, workflow `release-django-bananas.yml`. After a successful publish, the `NPM_TOKEN` secret can be removed.

## Changed areas
- `.github/workflows/release-django-bananas.yml`
